### PR TITLE
correct SimpleHashKeyGenerator to ensure key unicity for big arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+Current master branch
+---------------------
+
+* [#10] correct SimpleHashKeyGenerator to ensure key unicity for big arrays. **BC break : this change will affect how `SimpleHashKeyGenerator` generates cache keys. Consequently, if you use this generator, your cache will be invalidated.**

--- a/Cache/KeyGenerator/SimpleHashKeyGenerator.php
+++ b/Cache/KeyGenerator/SimpleHashKeyGenerator.php
@@ -29,9 +29,9 @@ class SimpleHashKeyGenerator implements KeyGeneratorInterface
             if (null == $parameter) {
                 $paramHash = 5678;
             } elseif (is_scalar($parameter)) {
-                $paramHash = md5($parameter);
+                $paramHash = sha1($parameter);
             } elseif (is_array($parameter) || is_object($parameter)) {
-                $paramHash = md5(serialize($parameter));
+                $paramHash = sha1(serialize($parameter));
             } else {
                 throw new UnsupportedKeyParameterException(sprintf('Not supported parameter type "%s"',
                     gettype($parameter)));
@@ -40,6 +40,6 @@ class SimpleHashKeyGenerator implements KeyGeneratorInterface
             $hash = $hash . $paramHash;
         }
 
-        return base_convert($hash, 16, 10);
+        return sha1($hash);
     }
 }

--- a/Tests/Cache/KeyGenerator/SimpleHashKeyGeneratorTest.php
+++ b/Tests/Cache/KeyGenerator/SimpleHashKeyGeneratorTest.php
@@ -20,21 +20,21 @@ class SimpleHashKeyGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testSingleScalarParameter()
     {
-        $expected = base_convert(1234 . md5('foo'), 16, 10);
+        $expected = sha1(1234 . sha1('foo'));
 
         $this->assertEquals($expected, $this->generator->generateKey('foo'));
     }
 
     public function testArrayOfScalarParameters()
     {
-        $expected = base_convert(1234 . md5('foo') . md5('bar'), 16, 10);
+        $expected = sha1(1234 . sha1('foo') . sha1('bar'));
 
         $this->assertEquals($expected, $this->generator->generateKey(array('foo', 'bar')));
     }
 
     public function testNullParameter()
     {
-        $expected = base_convert(1234 . 5678, 16, 10);
+        $expected = sha1(1234 . 5678);
 
         $this->assertEquals($expected, $this->generator->generateKey(null));
     }
@@ -42,7 +42,7 @@ class SimpleHashKeyGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testArrayParameter()
     {
         $parameter = array('foo', 'bar');
-        $expected = base_convert(1234 . md5(serialize($parameter)), 16, 10);
+        $expected = sha1(1234 . sha1(serialize($parameter)));
 
         $this->assertEquals($expected, $this->generator->generateKey(array($parameter)));
     }
@@ -54,7 +54,7 @@ class SimpleHashKeyGeneratorTest extends \PHPUnit_Framework_TestCase
         $param3 = 'foo';
         $param4 = null;
 
-        $expected = base_convert(1234 . md5(serialize($param1)) . md5(serialize($param2)) . md5($param3) . 5678, 16, 10);
+        $expected = sha1(1234 . sha1(serialize($param1)) . sha1(serialize($param2)) . sha1($param3) . 5678);
 
         $this->assertEquals($expected, $this->generator->generateKey(array(
             $param1,
@@ -62,6 +62,14 @@ class SimpleHashKeyGeneratorTest extends \PHPUnit_Framework_TestCase
             $param3,
             $param4
         )));
+    }
+
+    public function testBigArraysDontProduceSameKey()
+    {
+        $firstHash = $this->generator->generateKey(array('foo', 'bar', 'baz', 'unicorn'));
+        $secondHash = $this->generator->generateKey(array('foo', 'bar', 'baz', 'poney'));
+
+        $this->assertNotEquals($firstHash, $secondHash);
     }
 }
 


### PR DESCRIPTION
base_convert() with large numbers have some issues. 
See warning : http://php.net//manual/en/function.base-convert.php

I had a unit test as a proof and choose to use md5() again on the final hash (there is maybe a better solution ?).
